### PR TITLE
fix: bind attributes before program linking

### DIFF
--- a/src/utils/gl.js
+++ b/src/utils/gl.js
@@ -22,17 +22,16 @@ export function createProgram(gl, vsSrc, fsSrc, attribs = {}) {
   const prog = gl.createProgram();
   gl.attachShader(prog, vs);
   gl.attachShader(prog, fs);
+  // bind attrib locations if requested. This must happen before linking
+  // otherwise the requested locations will be ignored by WebGL.
+  for (const [name, loc] of Object.entries(attribs)) {
+    gl.bindAttribLocation(prog, loc, name);
+  }
   gl.linkProgram(prog);
   if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
     const info = gl.getProgramInfoLog(prog);
     gl.deleteProgram(prog);
     throw new Error('Program link error: ' + info);
-  }
-  // bind attrib locations if requested
-  let idx = 0;
-  for (const [name, loc] of Object.entries(attribs)) {
-    gl.bindAttribLocation(prog, loc, name);
-    idx++;
   }
   return prog;
 }


### PR DESCRIPTION
## Summary
- ensure attribute locations are bound before linking WebGL programs so custom locations take effect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689899a91dd8832785fbda000f3c0bb3