### PR TITLE
feat: add GPU transform feedback particle system

### DIFF
--- a/src/shaders/particles.vs
+++ b/src/shaders/particles.vs
@@ -3,12 +3,21 @@ attribute vec3 a_pos;
 attribute float a_size;
 attribute float a_brightness;
 attribute float a_type; // 0=beta,1=alpha
+attribute float a_active;
 uniform mat4 u_viewProj;
 varying float v_bright;
 varying float v_type;
 void main(){
   v_bright = a_brightness;
   v_type = a_type;
+  // Cull inactive particles by moving them off-screen and giving them a size
+  // of zero. This allows us to draw a fixed number of vertices every frame
+  // without updating an index buffer.
+  if (a_active < 0.5) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
   vec4 clip = u_viewProj * vec4(a_pos, 1.0);
   gl_Position = clip;
   float size = a_size / max(0.1, clip.w);

--- a/src/shaders/particles2d.vs
+++ b/src/shaders/particles2d.vs
@@ -3,12 +3,18 @@ attribute vec3 a_pos;
 attribute float a_size;
 attribute float a_brightness;
 attribute float a_type;
+attribute float a_active;
 uniform float u_bounds;
 varying float v_bright;
 varying float v_type;
 void main(){
   v_bright = a_brightness;
   v_type = a_type;
+  if (a_active < 0.5) {
+    gl_Position = vec4(2.0, 2.0, 0.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
+  }
   gl_Position = vec4(a_pos.x/u_bounds, a_pos.z/u_bounds, 0.0, 1.0);
   gl_PointSize = a_size;
 }

--- a/src/shaders/update.fs
+++ b/src/shaders/update.fs
@@ -1,0 +1,3 @@
+#version 300 es
+precision highp float;
+void main(){}

--- a/src/shaders/update.vs
+++ b/src/shaders/update.vs
@@ -1,0 +1,55 @@
+#version 300 es
+precision highp float;
+
+in vec4 a_state1; // xyz, life
+in vec4 a_state2; // vx vy vz type
+in vec4 a_state3; // size, bright, active, qScale
+
+uniform float u_dt;
+uniform float u_bounds;
+uniform float u_dragBase;
+uniform float u_jitter;
+uniform float u_B;
+
+out vec4 v_state1;
+out vec4 v_state2;
+out vec4 v_state3;
+
+float rand(float seed) {
+  return fract(sin(seed) * 43758.5453123);
+}
+
+void main() {
+  vec3 pos = a_state1.xyz;
+  float life = a_state1.w;
+  vec3 vel = a_state2.xyz;
+  float type = a_state2.w;
+  float size = a_state3.x;
+  float bright = a_state3.y;
+  float bActive = a_state3.z;
+  float qScale = a_state3.w;
+
+  if (bActive > 0.5) {
+    float qBase = type > 0.5 ? 0.6 : 1.0;
+    float q = qBase * qScale;
+    vec3 Bvec = vec3(0.0, u_B, 0.0);
+    vec3 acc = q * cross(vel, Bvec);
+    vel += acc * u_dt;
+    float drag = exp(-u_dragBase * u_dt);
+    vel *= drag;
+    float seed = float(gl_VertexID);
+    vel += vec3(
+      (rand(seed * 12.9898) * 2.0 - 1.0) * u_jitter * u_dt,
+      (rand(seed * 78.233) * 2.0 - 1.0) * u_jitter * u_dt * 0.5,
+      (rand(seed * 37.719) * 2.0 - 1.0) * u_jitter * u_dt
+    );
+    pos += vel * u_dt;
+    life -= u_dt;
+    bActive = (life > 0.0 && all(lessThan(abs(pos), vec3(u_bounds)))) ? 1.0 : 0.0;
+    bright = bright * max(0.25, life * 0.15);
+  }
+
+  v_state1 = vec4(pos, life);
+  v_state2 = vec4(vel, type);
+  v_state3 = vec4(size, bright, bActive, qScale);
+}


### PR DESCRIPTION
## Summary
- switch context creation to WebGL2 and add transform feedback support helpers
- move particle state to GPU buffers using transform feedback, allowing 50k+ particles
- add shaders and attribute updates to skip inactive particles on draw
- unbind transform feedback buffers after update pass and rename `bActive` flag to avoid reserved-word conflicts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898aca880a48327a5e7bfed5bc5e180