### PR TITLE
Enhance vapor trail realism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebGL Cloud Chamber (3D, Webpack)
 
-A minimal single-page WebGL simulation of a cloud chamber. Tracks are rendered as glowing points with an accumulation buffer to create fading trails. Curvature depends on a user-controlled magnetic field; track thickness and brightness depend on the "vapor" setting. Click to inject an ionization event; drag to orbit the camera; scroll to zoom.
+A minimal single-page WebGL simulation of a cloud chamber. Tracks are rendered with an accumulation buffer that diffuses and blurs to create cloudy, vapor-like trails. Curvature depends on a user-controlled magnetic field; track thickness and brightness depend on the "vapor" setting. Click to inject an ionization event; drag to orbit the camera; scroll to zoom.
 
 ## Run (dev)
 

--- a/src/index.js
+++ b/src/index.js
@@ -464,6 +464,7 @@ function renderTo(targetFBO, texPrev, decay) {
   gl.bindTexture(gl.TEXTURE_2D, texPrev);
   gl.uniform1i(gl.getUniformLocation(decayProg, 'u_prev'), 0);
   gl.uniform1f(gl.getUniformLocation(decayProg, 'u_decay'), decay);
+  gl.uniform2f(gl.getUniformLocation(decayProg, 'u_texel'), 1 / W, 1 / H);
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 
   // 2) draw particles (ADDITIVE)
@@ -488,6 +489,7 @@ function renderDensity(targetFBO, texPrev, decay) {
   gl.bindTexture(gl.TEXTURE_2D, texPrev);
   gl.uniform1i(gl.getUniformLocation(decayProg, 'u_prev'), 0);
   gl.uniform1f(gl.getUniformLocation(decayProg, 'u_decay'), decay);
+  gl.uniform2f(gl.getUniformLocation(decayProg, 'u_texel'), 1 / DENS_RES, 1 / DENS_RES);
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 
   gl.enable(gl.BLEND);

--- a/src/shaders/decay.fs
+++ b/src/shaders/decay.fs
@@ -2,7 +2,12 @@ precision highp float;
 varying vec2 v_uv;
 uniform sampler2D u_prev;
 uniform float u_decay;
+uniform vec2 u_texel;
 void main(){
-  vec4 col = texture2D(u_prev, v_uv);
+  vec4 col = texture2D(u_prev, v_uv) * 0.4;
+  col += texture2D(u_prev, v_uv + u_texel * vec2(1.0, 0.0)) * 0.15;
+  col += texture2D(u_prev, v_uv + u_texel * vec2(-1.0, 0.0)) * 0.15;
+  col += texture2D(u_prev, v_uv + u_texel * vec2(0.0, 1.0)) * 0.15;
+  col += texture2D(u_prev, v_uv + u_texel * vec2(0.0, -1.0)) * 0.15;
   gl_FragColor = vec4(col.rgb * u_decay, 1.0);
 }

--- a/src/shaders/particles.fs
+++ b/src/shaders/particles.fs
@@ -1,13 +1,19 @@
 precision highp float;
 varying float v_bright;
 varying float v_type;
+
+float hash(float n){ return fract(sin(n) * 43758.5453123); }
+float noise(vec2 p){ return hash(p.x * 12.9898 + p.y * 78.233); }
+
 void main(){
-  vec2 p = gl_PointCoord*2.0 - 1.0;
+  vec2 p = gl_PointCoord * 2.0 - 1.0;
   float r = length(p);
-  float disk = smoothstep(1.0, 0.6, r);
+  float density = exp(-2.5 * r * r);
+  float n = noise(p + v_bright);
+  density *= mix(0.7, 1.3, n);
   float core = mix(0.9, 1.3, v_type);
   float glow = mix(0.6, 1.0, v_type);
-  vec3 col = vec3(1.0) * (v_bright*core);
-  float alpha = disk * glow;
+  vec3 col = vec3(1.0) * (v_bright * core * density);
+  float alpha = density * glow;
   gl_FragColor = vec4(col, alpha);
 }


### PR DESCRIPTION
## Summary
- Add noisy particle shader and diffusion blur to create cloudy, vapor-like trails
- Pass texel size to decay shader for blur sampling
- Document updated trail appearance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899595a2de88327b0b883b993038163