### PR TITLE
Add WebGL1 fallback for unsupported devices

### DIFF
--- a/src/utils/gl.js
+++ b/src/utils/gl.js
@@ -2,8 +2,12 @@
 // simulation is only available in WebGL2, so we request that explicitly and
 // fail fast if the browser does not support it.
 export function createGL(canvas) {
-  const gl = canvas.getContext('webgl2', { alpha: false, antialias: true, preserveDrawingBuffer: false });
-  if (!gl) throw new Error('WebGL2 not supported');
+  // Try WebGL2 first for transform feedback support, then fall back to WebGL1
+  let gl = canvas.getContext('webgl2', { alpha: false, antialias: true, preserveDrawingBuffer: false });
+  if (gl) return gl;
+  gl = canvas.getContext('webgl', { alpha: false, antialias: true, preserveDrawingBuffer: false }) ||
+       canvas.getContext('experimental-webgl', { alpha: false, antialias: true, preserveDrawingBuffer: false });
+  if (!gl) throw new Error('WebGL not supported');
   return gl;
 }
 


### PR DESCRIPTION
## Summary
- Add WebGL1 context fallback when WebGL2 is unavailable
- Detect WebGL2 capability and reduce particle count for CPU-based simulation
- Update particle system to support CPU updates and manual buffer uploads

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b1a392f483279078a467714469c5