### PR TITLE
fix: correct source link and bundle path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -57,9 +57,9 @@
       </div>
     </div>
     <div class="panel about">
-      <p><strong>WebGL Cloud Chamber</strong> – a GPU particle demo built as a test of GPT-5 capabilities. Learn more about <a href="https://en.wikipedia.org/wiki/Cloud_chamber">cloud chambers</a> or browse the <a href="https://github.com/">source on GitHub</a>.</p>
+      <p><strong>WebGL Cloud Chamber</strong> – a GPU particle demo built as a test of GPT-5 capabilities. Learn more about <a href="https://en.wikipedia.org/wiki/Cloud_chamber">cloud chambers</a> or browse the <a href="https://github.com/NotMyWing/GPT-Cloud-Chamber">source on GitHub</a>.</p>
     </div>
   </div>
-  <script src="/bundle.js"></script>
+  <script src="./bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link to the GitHub repository in the About panel
- load the bundle via relative path `./bundle.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b247451c832785967106ff89eb62