### PR TITLE
Add social metadata and favicon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,19 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WebGL Cloud Chamber</title>
+  <meta name="description" content="WebGL 3D cloud chamber simulation with GPU particle trails.">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20100%20100'%3E%3Ctext%20y%3D'.9em'%20font-size%3D'90'%3E%E2%98%81%EF%B8%8F%3C%2Ftext%3E%3C%2Fsvg%3E">
+  <link rel="canonical" href="https://notmywing.github.io/GPT-Cloud-Chamber/">
+  <meta name="theme-color" content="#000000">
+  <meta property="og:title" content="WebGL Cloud Chamber">
+  <meta property="og:description" content="Explore a WebGL 3D cloud chamber simulation with particle trails.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://notmywing.github.io/GPT-Cloud-Chamber/">
+  <meta property="og:image" content="https://placehold.co/1200x630.png?text=WebGL%20Cloud%20Chamber">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="WebGL Cloud Chamber">
+  <meta name="twitter:description" content="Explore a WebGL 3D cloud chamber simulation with particle trails.">
+  <meta name="twitter:image" content="https://placehold.co/1200x630.png?text=WebGL%20Cloud%20Chamber">
   <style>
     html, body { margin:0; padding:0; height:100%; background:#000; overflow:hidden; color:#ccc; font-family:system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     #app, canvas { width:100%; height:100%; display:block; }


### PR DESCRIPTION
## Summary
- inline SVG favicon instead of binary asset
- reference external placeholder for Open Graph/Twitter preview images
- remove local binary images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c62dec888327bc051fef3e0cdd22