### PR TITLE
Render glass chamber with dynamic vapor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
       <label for="rRange">Activity</label>
       <input id="rRange" type="range" min="0" max="400" step="1" value="160">
       <label for="trailRange">Trail</label>
-      <input id="trailRange" type="range" min="0.80" max="0.999" step="0.001" value="0.965">
+      <input id="trailRange" type="range" min="0.80" max="0.999" step="0.001" value="0.95">
       <label for="isoSelect">Isotope</label>
       <select id="isoSelect">
         <option>Ambient (α+β)</option>

--- a/src/index.js
+++ b/src/index.js
@@ -705,7 +705,7 @@ function present(tex, t) {
   gl.useProgram(edgeProg);
   bindEdgeAttribs(edgeProg);
   gl.uniformMatrix4fv(gl.getUniformLocation(edgeProg, 'u_viewProj'), false, getViewProj());
-  gl.uniform3f(gl.getUniformLocation(edgeProg, 'u_color'), 0.2, 0.3, 0.35);
+  gl.uniform3f(gl.getUniformLocation(edgeProg, 'u_color'), 0.4, 0.6, 0.7);
   gl.lineWidth(3);
   gl.drawArrays(gl.LINES, 0, 24);
   gl.lineWidth(1);

--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,7 @@ gl.bindBuffer(gl.ARRAY_BUFFER, edgeVBO);
 gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(EV), gl.STATIC_DRAW);
 
 // vapor volume slices
-const VAPOR_SLICES = 32;
+const VAPOR_SLICES = 48;
 const vaporVBO = gl.createBuffer();
 (function initVapor() {
   const verts = [];
@@ -675,11 +675,15 @@ function present(tex, t) {
   gl.enable(gl.BLEND);
   gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   gl.enable(gl.DEPTH_TEST);
+  gl.depthMask(true);
+  gl.clear(gl.DEPTH_BUFFER_BIT);
+  gl.depthMask(false);
   gl.useProgram(vaporProg);
   bindVaporAttribs(vaporProg);
   gl.uniformMatrix4fv(gl.getUniformLocation(vaporProg, 'u_viewProj'), false, getViewProj());
   gl.uniform1f(gl.getUniformLocation(vaporProg, 'u_time'), t / 1000.0);
   gl.drawArrays(gl.TRIANGLES, 0, VAPOR_SLICES * 6);
+  gl.depthMask(true);
 
   // draw glass cube
   gl.useProgram(glassProg);

--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,7 @@ gl.bindBuffer(gl.ARRAY_BUFFER, edgeVBO);
 gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(EV), gl.STATIC_DRAW);
 
 // vapor volume slices
-const VAPOR_SLICES = 48;
+const VAPOR_SLICES = 96;
 const vaporVBO = gl.createBuffer();
 (function initVapor() {
   const verts = [];
@@ -691,7 +691,14 @@ function present(tex, t) {
   const eye = getCameraPos();
   gl.uniformMatrix4fv(gl.getUniformLocation(glassProg, 'u_viewProj'), false, getViewProj());
   gl.uniform3f(gl.getUniformLocation(glassProg, 'u_eye'), eye[0], eye[1], eye[2]);
+  gl.depthMask(false);
+  gl.enable(gl.CULL_FACE);
+  gl.cullFace(gl.FRONT);
   gl.drawArrays(gl.TRIANGLES, 0, 36);
+  gl.cullFace(gl.BACK);
+  gl.drawArrays(gl.TRIANGLES, 0, 36);
+  gl.disable(gl.CULL_FACE);
+  gl.depthMask(true);
 
   // draw edge lines on top
   gl.disable(gl.BLEND);

--- a/src/shaders/edge.fs
+++ b/src/shaders/edge.fs
@@ -1,0 +1,5 @@
+precision highp float;
+uniform vec3 u_color;
+void main(){
+  gl_FragColor = vec4(u_color,1.0);
+}

--- a/src/shaders/edge.vs
+++ b/src/shaders/edge.vs
@@ -1,0 +1,5 @@
+attribute vec3 a_pos;
+uniform mat4 u_viewProj;
+void main(){
+  gl_Position = u_viewProj * vec4(a_pos,1.0);
+}

--- a/src/shaders/glass.fs
+++ b/src/shaders/glass.fs
@@ -1,0 +1,13 @@
+precision highp float;
+varying vec3 v_norm;
+varying vec3 v_pos;
+uniform vec3 u_eye;
+void main(){
+  vec3 N = normalize(v_norm);
+  vec3 V = normalize(u_eye - v_pos);
+  float fres = pow(1.0 - max(dot(V, N), 0.0), 3.0);
+  vec3 base = vec3(0.4,0.6,0.7) * 0.2;
+  vec3 refl = vec3(0.9);
+  vec3 col = mix(base, refl, fres);
+  gl_FragColor = vec4(col, 0.2);
+}

--- a/src/shaders/glass.fs
+++ b/src/shaders/glass.fs
@@ -5,9 +5,11 @@ uniform vec3 u_eye;
 void main(){
   vec3 N = normalize(v_norm);
   vec3 V = normalize(u_eye - v_pos);
-  float fres = pow(1.0 - max(dot(V, N), 0.0), 3.0);
-  vec3 base = vec3(0.4,0.6,0.7) * 0.2;
+  float fres = pow(1.0 - max(dot(V, N), 0.0), 5.0);
+  vec3 tint = vec3(0.4, 0.6, 0.7) * 0.15;
   vec3 refl = vec3(0.9);
-  vec3 col = mix(base, refl, fres);
-  gl_FragColor = vec4(col, 0.2);
+  vec3 col = mix(tint, refl, fres);
+  float spec = pow(max(dot(reflect(-V, N), vec3(0.0,0.0,1.0)), 0.0), 16.0);
+  col += vec3(spec);
+  gl_FragColor = vec4(col, 0.15 + 0.15 * fres);
 }

--- a/src/shaders/glass.fs
+++ b/src/shaders/glass.fs
@@ -8,7 +8,7 @@ void main(){
   vec3 Nf = faceforward(N, V, N);
   float fres = pow(1.0 - max(dot(V, Nf), 0.0), 5.0);
   vec3 tint = vec3(0.4, 0.6, 0.7) * 0.15;
-  vec3 refl = vec3(0.9);
+  vec3 refl = vec3(0.1);
   vec3 col = mix(tint, refl, fres);
   float spec = pow(max(dot(reflect(-V, Nf), vec3(0.0,0.0,1.0)), 0.0), 16.0);
   col += vec3(spec);

--- a/src/shaders/glass.fs
+++ b/src/shaders/glass.fs
@@ -5,11 +5,12 @@ uniform vec3 u_eye;
 void main(){
   vec3 N = normalize(v_norm);
   vec3 V = normalize(u_eye - v_pos);
-  float fres = pow(1.0 - max(dot(V, N), 0.0), 5.0);
+  vec3 Nf = faceforward(N, V, N);
+  float fres = pow(1.0 - max(dot(V, Nf), 0.0), 5.0);
   vec3 tint = vec3(0.4, 0.6, 0.7) * 0.15;
   vec3 refl = vec3(0.9);
   vec3 col = mix(tint, refl, fres);
-  float spec = pow(max(dot(reflect(-V, N), vec3(0.0,0.0,1.0)), 0.0), 16.0);
+  float spec = pow(max(dot(reflect(-V, Nf), vec3(0.0,0.0,1.0)), 0.0), 16.0);
   col += vec3(spec);
   gl_FragColor = vec4(col, 0.15 + 0.15 * fres);
 }

--- a/src/shaders/glass.vs
+++ b/src/shaders/glass.vs
@@ -1,0 +1,10 @@
+attribute vec3 a_pos;
+attribute vec3 a_norm;
+uniform mat4 u_viewProj;
+varying vec3 v_norm;
+varying vec3 v_pos;
+void main(){
+  v_norm = a_norm;
+  v_pos = a_pos;
+  gl_Position = u_viewProj * vec4(a_pos, 1.0);
+}

--- a/src/shaders/vapor.fs
+++ b/src/shaders/vapor.fs
@@ -36,6 +36,6 @@ float fbm(vec3 p){
 void main(){
   vec3 p = v_pos * 0.1 + vec3(0.0, u_time * 0.02, 0.0);
   float d = fbm(p);
-  float alpha = smoothstep(0.5, 0.9, d) * 0.08;
+  float alpha = smoothstep(0.5, 0.9, d) * 0.04;
   gl_FragColor = vec4(vec3(0.9), alpha);
 }

--- a/src/shaders/vapor.fs
+++ b/src/shaders/vapor.fs
@@ -1,0 +1,8 @@
+precision highp float;
+void main(){
+  vec2 c = gl_PointCoord - 0.5;
+  float d = length(c);
+  if(d > 0.5) discard;
+  float alpha = (0.5 - d) * 0.3;
+  gl_FragColor = vec4(0.8,0.8,0.85, alpha);
+}

--- a/src/shaders/vapor.fs
+++ b/src/shaders/vapor.fs
@@ -1,27 +1,41 @@
 precision highp float;
-varying vec2 v_phase;
+varying vec3 v_pos;
 uniform float u_time;
 
-float hash(vec2 p){
-  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+float hash(vec3 p){
+  return fract(sin(dot(p, vec3(127.1,311.7,74.7))) * 43758.5453123);
 }
 
-float noise(vec2 p){
-  vec2 i = floor(p);
-  vec2 f = fract(p);
-  float a = hash(i);
-  float b = hash(i + vec2(1.0, 0.0));
-  float c = hash(i + vec2(0.0, 1.0));
-  float d = hash(i + vec2(1.0, 1.0));
-  vec2 u = f * f * (3.0 - 2.0 * f);
-  return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+float noise(vec3 p){
+  vec3 i = floor(p);
+  vec3 f = fract(p);
+  float n000 = hash(i);
+  float n100 = hash(i + vec3(1.0,0.0,0.0));
+  float n010 = hash(i + vec3(0.0,1.0,0.0));
+  float n110 = hash(i + vec3(1.0,1.0,0.0));
+  float n001 = hash(i + vec3(0.0,0.0,1.0));
+  float n101 = hash(i + vec3(1.0,0.0,1.0));
+  float n011 = hash(i + vec3(0.0,1.0,1.0));
+  float n111 = hash(i + vec3(1.0,1.0,1.0));
+  vec3 u = f*f*(3.0-2.0*f);
+  return mix(mix(mix(n000,n100,u.x), mix(n010,n110,u.x), u.y),
+             mix(mix(n001,n101,u.x), mix(n011,n111,u.x), u.y), u.z);
+}
+
+float fbm(vec3 p){
+  float v = 0.0;
+  float a = 0.5;
+  for(int i=0;i<4;i++){
+    v += a * noise(p);
+    p *= 2.0;
+    a *= 0.5;
+  }
+  return v;
 }
 
 void main(){
-  vec2 c = gl_PointCoord - 0.5;
-  float d = length(c);
-  if(d > 0.5) discard;
-  float n = noise((c * 4.0) + v_phase + u_time * 0.05);
-  float alpha = smoothstep(0.5, 0.0, d) * (0.25 + 0.35 * n);
+  vec3 p = v_pos * 0.1 + vec3(0.0, u_time * 0.02, 0.0);
+  float d = fbm(p);
+  float alpha = smoothstep(0.5, 0.9, d) * 0.08;
   gl_FragColor = vec4(vec3(0.9), alpha);
 }

--- a/src/shaders/vapor.fs
+++ b/src/shaders/vapor.fs
@@ -1,8 +1,27 @@
 precision highp float;
+varying vec2 v_phase;
+uniform float u_time;
+
+float hash(vec2 p){
+  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+float noise(vec2 p){
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  float a = hash(i);
+  float b = hash(i + vec2(1.0, 0.0));
+  float c = hash(i + vec2(0.0, 1.0));
+  float d = hash(i + vec2(1.0, 1.0));
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
 void main(){
   vec2 c = gl_PointCoord - 0.5;
   float d = length(c);
   if(d > 0.5) discard;
-  float alpha = (0.5 - d) * 0.3;
-  gl_FragColor = vec4(0.8,0.8,0.85, alpha);
+  float n = noise((c * 4.0) + v_phase + u_time * 0.05);
+  float alpha = smoothstep(0.5, 0.0, d) * (0.25 + 0.35 * n);
+  gl_FragColor = vec4(vec3(0.9), alpha);
 }

--- a/src/shaders/vapor.fs
+++ b/src/shaders/vapor.fs
@@ -36,6 +36,6 @@ float fbm(vec3 p){
 void main(){
   vec3 p = v_pos * 0.1 + vec3(0.0, u_time * 0.02, 0.0);
   float d = fbm(p);
-  float alpha = smoothstep(0.5, 0.9, d) * 0.04;
-  gl_FragColor = vec4(vec3(0.9), alpha);
+  float alpha = smoothstep(0.6, 0.9, d) * 0.025;
+  gl_FragColor = vec4(vec3(1.0), alpha);
 }

--- a/src/shaders/vapor.vs
+++ b/src/shaders/vapor.vs
@@ -1,7 +1,10 @@
 attribute vec3 a_pos;
+attribute vec2 a_phase;
 uniform mat4 u_viewProj;
 uniform float u_size;
+varying vec2 v_phase;
 void main(){
+  v_phase = a_phase;
   gl_Position = u_viewProj * vec4(a_pos, 1.0);
   gl_PointSize = u_size;
 }

--- a/src/shaders/vapor.vs
+++ b/src/shaders/vapor.vs
@@ -1,0 +1,7 @@
+attribute vec3 a_pos;
+uniform mat4 u_viewProj;
+uniform float u_size;
+void main(){
+  gl_Position = u_viewProj * vec4(a_pos, 1.0);
+  gl_PointSize = u_size;
+}

--- a/src/shaders/vapor.vs
+++ b/src/shaders/vapor.vs
@@ -1,10 +1,7 @@
 attribute vec3 a_pos;
-attribute vec2 a_phase;
 uniform mat4 u_viewProj;
-uniform float u_size;
-varying vec2 v_phase;
+varying vec3 v_pos;
 void main(){
-  v_phase = a_phase;
+  v_pos = a_pos;
   gl_Position = u_viewProj * vec4(a_pos, 1.0);
-  gl_PointSize = u_size;
 }


### PR DESCRIPTION
## Summary
- Replace wireframe bounds with translucent glass cube
- Add animated vapor particles for subtle air currents

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899daebcba48327ae9ffce564c0e8ad