### PR TITLE
Load isotopes from JSON and build dropdown dynamically

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,17 +52,7 @@
       <label for="trailRange">Trail</label>
       <input id="trailRange" type="range" min="0.80" max="0.999" step="0.001" value="0.95">
       <label for="isoSelect">Isotope</label>
-      <select id="isoSelect">
-        <option>Ambient (α+β)</option>
-        <option>Am-241 (α)</option>
-        <option>Po-210 (α)</option>
-        <option>Rn-222 (α)</option>
-        <option>Sr-90 (β−)</option>
-        <option>Cs-137 (β−)</option>
-        <option>Co-60 (β−)</option>
-        <option>Th-232 chain (α+β)</option>
-        <option>Cosmic Muons (μ)</option>
-      </select>
+      <select id="isoSelect"></select>
       <div id="toggleBtn" class="btn">Pause</div>
       <div id="clearBtn" class="btn">Clear</div>
       <div id="densityBtn" class="btn">Density: Off</div>

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import edgeFS from './shaders/edge.fs';
 import updateVS from './shaders/update.vs';
 import updateFS from './shaders/update.fs';
 import { M4 } from './utils/m4';
+import ISOTOPES from './isotopes.json';
 
 
 // --- simulation parameters
@@ -24,28 +25,7 @@ const DT_MAX = 1 / 30;
 const BOUNDS = 20;
 const DENS_RES = 128;
 
-// track characteristics for each isotope
-const ISOTOPES = {
-  'Ambient (α+β)': {
-    mix: [
-      { type: 'alpha', frac: 0.30, speed: 2.2, life: 3.5, size: 26, bright: 1.05, qScale: 1.0 },
-      { type: 'beta', frac: 0.70, speed: 7.0, life: 7.0, size: 10, bright: 0.65, qScale: 1.0 }
-    ]
-  },
-  'Am-241 (α)': { mix: [{ type: 'alpha', frac: 1.0, speed: 2.1, life: 3.8, size: 28, bright: 1.15, qScale: 0.8 }] },
-  'Po-210 (α)': { mix: [{ type: 'alpha', frac: 1.0, speed: 2.0, life: 3.4, size: 28, bright: 1.20, qScale: 0.8 }] },
-  'Rn-222 (α)': { mix: [{ type: 'alpha', frac: 1.0, speed: 2.0, life: 3.2, size: 26, bright: 1.10, qScale: 0.85 }] },
-  'Sr-90 (β−)': { mix: [{ type: 'beta', frac: 1.0, speed: 6.5, life: 7.5, size: 9, bright: 0.60, qScale: 1.2 }] },
-  'Cs-137 (β−)': { mix: [{ type: 'beta', frac: 1.0, speed: 7.5, life: 8.0, size: 10, bright: 0.62, qScale: 1.2 }] },
-  'Co-60 (β−)': { mix: [{ type: 'beta', frac: 1.0, speed: 5.5, life: 6.8, size: 9, bright: 0.60, qScale: 1.1 }] },
-  'Th-232 chain (α+β)': {
-    mix: [
-      { type: 'alpha', frac: 0.60, speed: 2.0, life: 3.5, size: 27, bright: 1.10, qScale: 0.85 },
-      { type: 'beta', frac: 0.40, speed: 6.8, life: 7.5, size: 10, bright: 0.62, qScale: 1.15 }
-    ]
-  },
-  'Cosmic Muons (μ)': { cosmic: true }
-};
+// track characteristics for each isotope are loaded from JSON
 
 function pickComp(mix) {
   const r = Math.random();
@@ -442,6 +422,13 @@ const vSlider = document.getElementById('vRange');
 const rSlider = document.getElementById('rRange');
 const trailSlider = document.getElementById('trailRange');
 const isoSelect = document.getElementById('isoSelect');
+for (const name of Object.keys(ISOTOPES)) {
+  const opt = document.createElement('option');
+  opt.value = name;
+  opt.textContent = name;
+  isoSelect.appendChild(opt);
+}
+isoSelect.value = 'Ambient (α+β)';
 const toggleBtn = document.getElementById('toggleBtn');
 const clearBtn = document.getElementById('clearBtn');
 const densityBtn = document.getElementById('densityBtn');
@@ -458,8 +445,8 @@ function updateSettingsBtn() {
 }
 
 const isoActivities = {};
-for (const opt of isoSelect.options) {
-  isoActivities[opt.value] = parseFloat(rSlider.value);
+for (const name of Object.keys(ISOTOPES)) {
+  isoActivities[name] = parseFloat(rSlider.value);
 }
 isoActivities['Cosmic Muons (μ)'] = 5;
 isoSelect.addEventListener('change', () => {

--- a/src/isotopes.json
+++ b/src/isotopes.json
@@ -1,0 +1,21 @@
+{
+  "Ambient (α+β)": {
+    "mix": [
+      { "type": "alpha", "frac": 0.30, "speed": 2.2, "life": 3.5, "size": 26, "bright": 1.05, "qScale": 1.0 },
+      { "type": "beta", "frac": 0.70, "speed": 7.0, "life": 7.0, "size": 10, "bright": 0.65, "qScale": 1.0 }
+    ]
+  },
+  "Am-241 (α)": { "mix": [{ "type": "alpha", "frac": 1.0, "speed": 2.1, "life": 3.8, "size": 28, "bright": 1.15, "qScale": 0.8 }] },
+  "Po-210 (α)": { "mix": [{ "type": "alpha", "frac": 1.0, "speed": 2.0, "life": 3.4, "size": 28, "bright": 1.20, "qScale": 0.8 }] },
+  "Rn-222 (α)": { "mix": [{ "type": "alpha", "frac": 1.0, "speed": 2.0, "life": 3.2, "size": 26, "bright": 1.10, "qScale": 0.85 }] },
+  "Sr-90 (β−)": { "mix": [{ "type": "beta", "frac": 1.0, "speed": 6.5, "life": 7.5, "size": 9, "bright": 0.60, "qScale": 1.2 }] },
+  "Cs-137 (β−)": { "mix": [{ "type": "beta", "frac": 1.0, "speed": 7.5, "life": 8.0, "size": 10, "bright": 0.62, "qScale": 1.2 }] },
+  "Co-60 (β−)": { "mix": [{ "type": "beta", "frac": 1.0, "speed": 5.5, "life": 6.8, "size": 9, "bright": 0.60, "qScale": 1.1 }] },
+  "Th-232 chain (α+β)": {
+    "mix": [
+      { "type": "alpha", "frac": 0.60, "speed": 2.0, "life": 3.5, "size": 27, "bright": 1.10, "qScale": 0.85 },
+      { "type": "beta", "frac": 0.40, "speed": 6.8, "life": 7.5, "size": 10, "bright": 0.62, "qScale": 1.15 }
+    ]
+  },
+  "Cosmic Muons (μ)": { "cosmic": true }
+}


### PR DESCRIPTION
## Summary
- move isotope definitions into new `src/isotopes.json`
- import isotopes data and generate dropdown options in code
- simplify HTML select so options come from JSON

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f8fc79d08327bb3e96bb70fc29f8