### PR TITLE
Boost particle visibility and flair

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -358,6 +358,10 @@ function randDir3() {
 
 // Write a particle into the current source buffers at the emit pointer.
 function emitParticle(x, y, z, vx, vy, vz, life, type, size, bright, qScale) {
+  // Boost visibility so newly spawned particles appear bold and flashy.
+  size *= 1.5;
+  bright *= 2.0;
+
   const idx = emitPtr;
   emitPtr = (emitPtr + 1) % MAX_PARTICLES;
   if (isWebGL2) {

--- a/src/index.js
+++ b/src/index.js
@@ -359,8 +359,8 @@ function randDir3() {
 // Write a particle into the current source buffers at the emit pointer.
 function emitParticle(x, y, z, vx, vy, vz, life, type, size, bright, qScale) {
   // Boost visibility so newly spawned particles appear bold and flashy.
-  size *= 1.5;
-  bright *= 2.0;
+  size *= 2.0;
+  bright *= 3.0;
 
   const idx = emitPtr;
   emitPtr = (emitPtr + 1) % MAX_PARTICLES;

--- a/src/shaders/decay.fs
+++ b/src/shaders/decay.fs
@@ -9,5 +9,5 @@ void main(){
   col += texture2D(u_prev, v_uv + u_texel * vec2(-1.0, 0.0)) * 0.15;
   col += texture2D(u_prev, v_uv + u_texel * vec2(0.0, 1.0)) * 0.15;
   col += texture2D(u_prev, v_uv + u_texel * vec2(0.0, -1.0)) * 0.15;
-  gl_FragColor = vec4(col.rgb * u_decay, 1.0);
+  gl_FragColor = vec4(col.rgb * u_decay * 1.3, 1.0);
 }

--- a/src/shaders/decay.fs
+++ b/src/shaders/decay.fs
@@ -9,5 +9,6 @@ void main(){
   col += texture2D(u_prev, v_uv + u_texel * vec2(-1.0, 0.0)) * 0.15;
   col += texture2D(u_prev, v_uv + u_texel * vec2(0.0, 1.0)) * 0.15;
   col += texture2D(u_prev, v_uv + u_texel * vec2(0.0, -1.0)) * 0.15;
-  gl_FragColor = vec4(col.rgb * u_decay * 1.3, 1.0);
+  float decay = min(u_decay + 0.05, 0.995);
+  gl_FragColor = vec4(col.rgb * decay, 1.0);
 }

--- a/src/shaders/particles.fs
+++ b/src/shaders/particles.fs
@@ -18,7 +18,7 @@ void main(){
   vec3 betaCol = vec3(0.3, 0.7, 1.0);
   vec3 alphaCol = vec3(1.0, 0.5, 0.1);
   vec3 col = mix(betaCol, alphaCol, v_type);
-  float brightness = v_bright * core * density * (1.8 + sparkle * 0.8);
+  float brightness = v_bright * core * (1.2 + sparkle * 0.8);
   float alpha = density * glow * (1.4 + sparkle * 0.5);
-  gl_FragColor = vec4(col * brightness, alpha);
+  gl_FragColor = vec4(col * brightness * density, alpha);
 }

--- a/src/shaders/particles.fs
+++ b/src/shaders/particles.fs
@@ -1,6 +1,7 @@
 precision highp float;
 varying float v_bright;
 varying float v_type;
+uniform float u_time;
 
 float hash(float n){ return fract(sin(n) * 43758.5453123); }
 float noise(vec2 p){ return hash(p.x * 12.9898 + p.y * 78.233); }
@@ -11,12 +12,13 @@ void main(){
   float density = exp(-2.5 * r * r);
   float n = noise(p + v_bright);
   density *= mix(0.7, 1.3, n);
+  float sparkle = step(0.95, noise(p * 40.0 + u_time * 5.0));
   float core = mix(0.9, 1.5, v_type);
   float glow = mix(1.0, 1.4, v_type);
   vec3 betaCol = vec3(0.3, 0.7, 1.0);
   vec3 alphaCol = vec3(1.0, 0.5, 0.1);
   vec3 col = mix(betaCol, alphaCol, v_type);
-  float brightness = v_bright * core * density * 1.8;
-  float alpha = density * glow * 1.4;
+  float brightness = v_bright * core * density * (1.8 + sparkle * 0.8);
+  float alpha = density * glow * (1.4 + sparkle * 0.5);
   gl_FragColor = vec4(col * brightness, alpha);
 }

--- a/src/shaders/particles.fs
+++ b/src/shaders/particles.fs
@@ -11,9 +11,12 @@ void main(){
   float density = exp(-2.5 * r * r);
   float n = noise(p + v_bright);
   density *= mix(0.7, 1.3, n);
-  float core = mix(0.9, 1.3, v_type);
-  float glow = mix(0.6, 1.0, v_type);
-  vec3 col = vec3(1.0) * (v_bright * core * density);
-  float alpha = density * glow;
-  gl_FragColor = vec4(col, alpha);
+  float core = mix(0.9, 1.5, v_type);
+  float glow = mix(1.0, 1.4, v_type);
+  vec3 betaCol = vec3(0.3, 0.7, 1.0);
+  vec3 alphaCol = vec3(1.0, 0.5, 0.1);
+  vec3 col = mix(betaCol, alphaCol, v_type);
+  float brightness = v_bright * core * density * 1.8;
+  float alpha = density * glow * 1.4;
+  gl_FragColor = vec4(col * brightness, alpha);
 }

--- a/src/shaders/vapor.fs
+++ b/src/shaders/vapor.fs
@@ -40,6 +40,7 @@ void main(){
   float d = fbm(p);
   vec2 uv = v_pos.xz / (2.0 * u_bounds) + 0.5;
   float trail = texture2D(u_dens, uv).r;
-  float alpha = smoothstep(0.6, 0.9, d) * 0.025 + trail * 0.3;
+  trail = pow(trail, 0.5) * exp(-abs(v_pos.y) * 0.1);
+  float alpha = smoothstep(0.6, 0.9, d) * 0.025 + trail * 0.1;
   gl_FragColor = vec4(vec3(1.0), alpha);
 }

--- a/src/shaders/vapor.fs
+++ b/src/shaders/vapor.fs
@@ -1,6 +1,8 @@
 precision highp float;
 varying vec3 v_pos;
 uniform float u_time;
+uniform sampler2D u_dens;
+uniform float u_bounds;
 
 float hash(vec3 p){
   return fract(sin(dot(p, vec3(127.1,311.7,74.7))) * 43758.5453123);
@@ -36,6 +38,8 @@ float fbm(vec3 p){
 void main(){
   vec3 p = v_pos * 0.1 + vec3(0.0, u_time * 0.02, 0.0);
   float d = fbm(p);
-  float alpha = smoothstep(0.6, 0.9, d) * 0.025;
+  vec2 uv = v_pos.xz / (2.0 * u_bounds) + 0.5;
+  float trail = texture2D(u_dens, uv).r;
+  float alpha = smoothstep(0.6, 0.9, d) * 0.025 + trail * 0.3;
   gl_FragColor = vec4(vec3(1.0), alpha);
 }


### PR DESCRIPTION
## Summary
- Amplify size and brightness of emitted particles for a bolder presence
- Add color-tinted glow and higher intensity in particle fragment shader for flashier tracks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899fbabcd208327878cb371c93a8d70