### PR TITLE
feat: add rendering settings with auto scaling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,33 +35,52 @@
     .controls h2 { margin:0 0 8px; font-size:16px; }
     .about { margin-top:20px; max-width:260px; }
     .about a { color:#8cf; }
+    .tabs { margin-bottom:10px; flex-direction:row; align-items:center; }
+    .tab { display:none; }
+    .tab.active { display:block; }
+    .tab-btn.active { background:rgba(255,255,255,0.18); }
   </style>
 </head>
 <body>
   <div id="app"></div>
   <div id="settingsBtn" class="btn settings-btn">⚙️ Settings</div>
   <div id="settingsPanel" class="panel sidebar controls">
-    <h2>Simulation Settings</h2>
-    <div class="row">
-      <label for="bRange">B-field</label>
-      <input id="bRange" type="range" min="-2" max="2" step="0.01" value="0.6">
-      <label for="vRange">Vapor</label>
-      <input id="vRange" type="range" min="0" max="1" step="0.005" value="0.35">
-      <label for="rRange">Activity</label>
-      <input id="rRange" type="range" min="0" max="400" step="1" value="160">
-      <label for="trailRange">Trail</label>
-      <input id="trailRange" type="range" min="0.80" max="0.999" step="0.001" value="0.95">
-      <label for="isoSelect">Isotope</label>
-      <select id="isoSelect"></select>
-      <div id="toggleBtn" class="btn">Pause</div>
-      <div id="clearBtn" class="btn">Clear</div>
-      <div id="densityBtn" class="btn">Density: Off</div>
+    <div class="row tabs">
+      <div id="simTabBtn" class="btn tab-btn active">Simulation</div>
+      <div id="renderTabBtn" class="btn tab-btn">Rendering</div>
     </div>
-    <div class="row tip">
-      Click to inject a decay. Drag = orbit. Wheel = zoom. Isotope controls α vs β track style (stylized).
+    <div id="simTab" class="tab active">
+      <h2>Simulation Settings</h2>
+      <div class="row">
+        <label for="bRange">B-field</label>
+        <input id="bRange" type="range" min="-2" max="2" step="0.01" value="0.6">
+        <label for="vRange">Vapor</label>
+        <input id="vRange" type="range" min="0" max="1" step="0.005" value="0.35">
+        <label for="rRange">Activity</label>
+        <input id="rRange" type="range" min="0" max="400" step="1" value="160">
+        <label for="trailRange">Trail</label>
+        <input id="trailRange" type="range" min="0.80" max="0.999" step="0.001" value="0.95">
+        <label for="isoSelect">Isotope</label>
+        <select id="isoSelect"></select>
+        <div id="toggleBtn" class="btn">Pause</div>
+        <div id="clearBtn" class="btn">Clear</div>
+        <div id="densityBtn" class="btn">Density: Off</div>
+      </div>
+      <div class="row tip">
+        Click to inject a decay. Drag = orbit. Wheel = zoom. Isotope controls α vs β track style (stylized).
+      </div>
+      <div class="about">
+        <p><strong>WebGL Cloud Chamber</strong> – a GPU particle demo built as a test of GPT-5 capabilities. Learn more about <a href="https://en.wikipedia.org/wiki/Cloud_chamber">cloud chambers</a> or browse the <a href="https://github.com/NotMyWing/GPT-Cloud-Chamber">source on GitHub</a>.</p>
+      </div>
     </div>
-    <div class="about">
-      <p><strong>WebGL Cloud Chamber</strong> – a GPU particle demo built as a test of GPT-5 capabilities. Learn more about <a href="https://en.wikipedia.org/wiki/Cloud_chamber">cloud chambers</a> or browse the <a href="https://github.com/NotMyWing/GPT-Cloud-Chamber">source on GitHub</a>.</p>
+    <div id="renderTab" class="tab">
+      <h2>Rendering Settings</h2>
+      <div class="row">
+        <label for="scaleRange">Scale</label>
+        <input id="scaleRange" type="range" min="0.5" max="1" step="0.05" value="1">
+        <label><input id="autoCheck" type="checkbox" checked>Auto</label>
+        <div id="resetRenderBtn" class="btn">Reset</div>
+      </div>
     </div>
   </div>
   <script src="./bundle.js"></script>


### PR DESCRIPTION
## Summary
- add rendering settings tab with resolution scale slider
- support auto/manual modes with reset and persistence
- dynamically adjust render scale based on runtime performance

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ab8405dbc8327ae1fc3f3ce36ec59